### PR TITLE
Changed back to loading two pictures for comparability with the newest Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,21 +40,17 @@ First, put the following PHP tag at the *top of your PHP document*
 ```
 
 
-Second, put the following PHP tag *within your document \<head>*
+Second, for the necessary styling, put the following link tag *within your document \<head>*
 
 ```
-<?php 
-   echo '<link href="../build/css/main.css" rel="stylesheet" >'; // Required styles for images
-?>
+<link href="../build/css/main.css" rel="stylesheet">
 ```
 
 
 Third, call the bundle.js file at the *bottom of your document \<body>*
 
 ```
-<?php
-   echo "<script src='../build/js/bundle.js'></script>"
-?>
+<script src='../build/js/bundle.js'></script>
 ```
 
 
@@ -85,16 +81,32 @@ Place the following tag wherever you would like to load an image, passing in the
 
 ### Customizing
 
-All img-load-manager images are placed within a div with the class "img-loader-container", which you can target for your CSS styles.
+By default, all img-load-manager images are placed within a div with the class "img-loader-container" and an id matching the image filename. You can target these elements for your CSS styling. 
 
 ```
 .img-loader-container {
    width: 50%;
    float: left;
+}
+
+#my-photo {
    padding: 5rem;
 }
 ```
+### Advanced Customization
 
+You can pass in an associate array as an optional second argument to your PHP call for further customization. 
+
+#### Here are the keys and values this associative array will take:
+* @param 'thumbWidth' {number} - Specify the desired width for the created thumbnail - *ex - 100*
+* @param 'thumbHeight' {number} - Specify the desired height for the created thumbnail - *ex - 50*
+* @param 'class' {string} - Specify the class(es) you to add to the image container. Seperate multiple class names by a space - *ex - 'gallery-images my-class'*
+* @param 'id' {string} - Specify the id to give the image container *ex - 'paris'*
+
+```
+<?php new ImgLdr('images/paris.jpg', array( "thumbHeight"=>300, "id"=>"paris", "class"=> "my-class my-images" )); ?>
+```
+*Note: If you pass both a `thumbWidth` and `thumbHeight` it may skew your image. If you pass only one or neither, the aspect ratio will be maintained*
 
 ## Authors
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ By default, all img-load-manager images are placed within a div with the class "
 You can pass in an associate array as an optional second argument to your PHP call for further customization. 
 
 #### Here are the keys and values this associative array will take:
-* `@param 'thumbWidth' {number}` - Specify the desired width for the created thumbnail \(*ex - 100*)
-* `@param 'thumbHeight' {number}` - Specify the desired height for the created thumbnail \(*ex - 50*)
-* `@param 'class' {string}` - Specify the class(es) you to add to the image container. Seperate multiple class names by a space \(*ex - 'gallery-images my-class'*)
-* `@param 'id' {string}` - Specify the id to give the image container \(*ex - 'paris'*)
+* `@param 'thumbWidth' {number}` - Specify the desired width for created thumbnail \(*ex - 100*)
+* `@param 'thumbHeight' {number}` - Specify the desired height for created thumbnail \(*ex - 50*)
+* `@param 'class' {string}` - Specify additional class(es) for image container. Seperate multiple classes by spaces \(*ex - 'gallery-images my-class'*)
+* `@param 'id' {string}` - Specify custom id to give the image container \(*ex - 'paris'*)
 
 ```
 <?php new ImgLdr('images/paris.jpg', array( "thumbHeight"=>300, "id"=>"paris", "class"=> "my-class my-images" )); ?>

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ By default, all img-load-manager images are placed within a div with the class "
 You can pass in an associate array as an optional second argument to your PHP call for further customization. 
 
 #### Here are the keys and values this associative array will take:
-* @param 'thumbWidth' {number} - Specify the desired width for the created thumbnail - *ex - 100*
-* @param 'thumbHeight' {number} - Specify the desired height for the created thumbnail - *ex - 50*
-* @param 'class' {string} - Specify the class(es) you to add to the image container. Seperate multiple class names by a space - *ex - 'gallery-images my-class'*
-* @param 'id' {string} - Specify the id to give the image container *ex - 'paris'*
+* `@param 'thumbWidth' {number}` - Specify the desired width for the created thumbnail \(*ex - 100*)
+* `@param 'thumbHeight' {number}` - Specify the desired height for the created thumbnail \(*ex - 50*)
+* `@param 'class' {string}` - Specify the class(es) you to add to the image container. Seperate multiple class names by a space \(*ex - 'gallery-images my-class'*)
+* `@param 'id' {string}` - Specify the id to give the image container \(*ex - 'paris'*)
 
 ```
 <?php new ImgLdr('images/paris.jpg', array( "thumbHeight"=>300, "id"=>"paris", "class"=> "my-class my-images" )); ?>

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -1,6 +1,7 @@
 * {
    margin: 0;
    padding: 0;
+   box-sizing: border-box;
 }
 
 body {
@@ -17,6 +18,6 @@ h1 {
 }
 
 .img-loader-container {
-   padding: 1rem 2rem;
+   margin: 1rem 2rem;
    margin-bottom: 4rem;
 }

--- a/demo/index.php
+++ b/demo/index.php
@@ -9,29 +9,24 @@
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <meta http-equiv="X-UA-Compatible" content="ie=edge">
    <title>Image Loader</title>
-   <?php 
-      echo '<link href="../build/css/main.css" rel="stylesheet">'; // Required styles for images
-   ?>
+   <link href="../build/css/main.css" rel="stylesheet">
    <link href="demo.css" rel="stylesheet">
 </head>
 <body>
    <h1>Image Gallery</h1>
    
    <h3>Aerial Paris</h3>
-   <?php new ImgLdr('images/paris.jpg'); ?>
+   <?php new ImgLdr('images/paris.jpg', array("thumbWidth"=>300, "id"=>"paris")); ?>
 
    <h3>Rooftops in France</h3>
-   <?php new ImgLdr('images/rooftops.jpg'); ?>
+   <?php new ImgLdr('images/rooftops.jpg', array("class"=>"awesome test")); ?>
 
    <h3>A Parisian Street</h3>
    <?php new ImgLdr('images/narrowroad.jpg'); ?>
 
    <h3>Umbrellas</h3>
-   <?php new ImgLdr('images/craig-whitehead-260310.jpg'); ?>
+   <?php new ImgLdr('images/craig-whitehead-260310.jpg', array("thumbHeight"=>50)); ?>
 
-   <?php
-      // Call the ImageLoaderScript class, telling the images to switch when the high-res photo finishes loading
-      echo "<script src='../build/js/bundle.js'></script>"
-   ?>
+   <script src='../build/js/bundle.js'></script>
 </body>
 </html>

--- a/src/js/img-loader-script.js
+++ b/src/js/img-loader-script.js
@@ -8,23 +8,24 @@ class ImageLoaderScript {
     * On instantiation, class will find and store designated pair of photos;
     */
    constructor(imageFilename) {
-      this.lowResPhotos = document.getElementsByClassName(
-         'img-loader__content'
+      this.lrPhotos = document.getElementsByClassName(
+         'img-loader-container'
       );
       this.swapAllImages();
    }
 
    /**
-   * Loops through all the photos in the lowResPhotos array
+   * Loops through all the photos in the lrPhotos array
    * Loads the high-res image and switches the source to it on load completion
    */
    swapAllImages() {
-      for (let i = 0; i < this.lowResPhotos.length; i++) {
-         const highResPhoto = new Image();
-         highResPhoto.src = this.lowResPhotos[i].id;
-         highResPhoto.onload = () => {
-            this.lowResPhotos[i].src = highResPhoto.src;
-            this.lowResPhotos[i].classList.remove('img-loader__blur');
+      for (let i = 0; i < this.lrPhotos.length; i++) {
+         const hrPhoto = new Image();
+         hrPhoto.src = this.lrPhotos[i].firstChild.id;
+         hrPhoto.classList.add('img-loader__content--hr');
+         hrPhoto.onload = () => {
+            this.lrPhotos[i].appendChild(hrPhoto);
+            hrPhoto.classList.add('img-loader__loaded');
          };
       }
    }

--- a/src/scss/main.scss
+++ b/src/scss/main.scss
@@ -1,1 +1,2 @@
 @import 'partials/img-loader';
+@import 'partials/animations';

--- a/src/scss/partials/_animations.scss
+++ b/src/scss/partials/_animations.scss
@@ -1,0 +1,4 @@
+@keyframes zoom-in {
+   0%   {transform: scale(1.1); filter: blur(10px);}
+   100% {transform: scale(1); filter: blur(0);}
+}

--- a/src/scss/partials/_img-loader.scss
+++ b/src/scss/partials/_img-loader.scss
@@ -1,23 +1,34 @@
 .img-loader {
    
-   &__wrapper {
-      position: relative;
+   &-container {
       overflow: hidden;
+      position: relative;
+      box-sizing: border-box;
    }
 
    &__content {
-      width: 100%;
-      backface-visibility: hidden;
-      -moz-backface-visibility: hidden;
-      -webkit-backface-visibility: hidden;
-      filter: blur(0);
-      transform: scale(1);
-      transition: all .5s linear;
+
+      &--hr,
+      &--lr {
+         width: 100%;
+         backface-visibility: hidden;
+         -moz-backface-visibility: hidden;
+         -webkit-backface-visibility: hidden;
+         filter: blur(20px);
+         transform: scale(1.1);
+      }
+
+      &--hr {
+         position: absolute;
+         top: 0;
+         left: 0;
+         width: 100%;
+         height: 100%;
+      }
    }
    
-   &__blur {
-      transform: scale(1.03);
-      filter: blur(10px);
+   &__loaded {
+      animation: zoom-in .8s linear both;   
    }
 }
 


### PR DESCRIPTION
The newest version of Firefox no longer allows smooth changing of an image source to another. 